### PR TITLE
feat: support configuring Virtual Network as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ with:
 - auth_client_secret - (required) The service token client secret.
 - version - (optional) The version of Cloudflare WARP to install. Defaults to
   the latest version.
+- vnet - (optional) The Virtual Network ID that you wish to use.
 
 ## Troubleshooting
 

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
     description: 'The number of times to retry the WARP setup'
     required: false
     default: 10
+  vnet:
+    description: 'The Virtual Network ID that you wish to use.'
+    required: false
 
 branding:
   icon: 'cloud-lightning'

--- a/src/libs/base-client.ts
+++ b/src/libs/base-client.ts
@@ -2,8 +2,9 @@ import * as exec from '@actions/exec';
 import type { ConfigurationParams } from '../types';
 
 abstract class BaseClient {
-  abstract writeConfigurations(
-    configuration: ConfigurationParams
+  abstract writeConfigurations({
+    vnet
+  }: ConfigurationParams
   ): Promise<void>;
   abstract install(version?: string): Promise<void>;
   abstract cleanup(): Promise<void>;
@@ -43,6 +44,21 @@ abstract class BaseClient {
     const connected = output.includes('Status update: Connected');
     if (!connected) {
       throw new Error('WARP is not connected');
+    }
+  }
+
+  async useVirtualNetwork(vnet: string) {
+    let output = '';
+    await exec.exec('warp-cli', ['--accept-tos', 'vnet', vnet], {
+      listeners: {
+        stdout: (data: Buffer) => {
+          output += data.toString();
+        }
+      }
+    });
+    const virtualNetworkSelected = output.includes('Success');
+    if (!virtualNetworkSelected) {
+      throw new Error(`Could not use Virtual Network with ID: ${vnet}`);
     }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,10 @@ export const main = async () => {
         trimWhitespace: true
       })
     );
+    const vnet = core.getInput('vnet', {
+      required: false,
+      trimWhitespace: true
+    })
 
     core.info(`Platform: ${process.platform}`);
     const client = getClient(process.platform);
@@ -45,6 +49,9 @@ export const main = async () => {
     });
 
     core.saveState('connected', 'true');
+    if (vnet !== "") {
+      await client.useVirtualNetwork(vnet);
+    }
   } catch (err) {
     core.setFailed((err as Error).message);
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,4 +2,5 @@ export type ConfigurationParams = {
   organization: string;
   authClientID: string;
   authClientSecret: string;
+  vnet: string;
 };


### PR DESCRIPTION
#### Description

It is common to use multiple virtual networks to handle overlapping IP ranges when using a cloudflare tunnel. Adding support for a vnet variable as input helps solve for this.

Note :- I got the same code merged at Boostport/setup-cloudflare-warp with this [commit](https://github.com/Boostport/setup-cloudflare-warp/commit/91441092c1bccb8841bd46503725fc63c2f67ced). Since we use both actions I was hoping we can add the same here as well :)